### PR TITLE
add dependency on libgit2 package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+compiled/
+*~

--- a/info.rkt
+++ b/info.rkt
@@ -2,3 +2,5 @@
 
 (define drracket-name "DrRackGit")
 (define drracket-tools (list (list "drrackgit.rkt")))
+
+(define deps '("libgit2"))


### PR DESCRIPTION
Without this dependency, installation of Drrackgit just fails because it can't find the libgit2 collection.